### PR TITLE
Int and float setting

### DIFF
--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/dialog/NumberPadDialog.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/dialog/NumberPadDialog.java
@@ -1,0 +1,170 @@
+package com.takaaki.urcap.eipmonitor.impl.dialog;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.*;
+
+public class NumberPadDialog extends JDialog {
+    private StringBuilder currentValue = new StringBuilder();
+    private boolean isNegative = false;
+    private boolean hasDecimal = false;
+    private boolean isValid = true;  // Track if the input is valid
+    private String resultValue = "";  // Store the result (valid or not)
+
+    public NumberPadDialog(JFrame parent) {
+        super(parent, "Enter Value", true);
+        setLayout(new BorderLayout());
+
+        // Display field for input
+        final JTextField display = new JTextField();
+        display.setEditable(false);
+        add(display, BorderLayout.NORTH);
+
+        // Panel for the number pad buttons
+        JPanel buttonPanel = new JPanel(new GridLayout(5, 3));  // 4 rows, 3 columns
+
+        // Add number buttons (7-9, 4-6, 1-3)
+        addButton(buttonPanel, "7", display);
+        addButton(buttonPanel, "8", display);
+        addButton(buttonPanel, "9", display);
+        addButton(buttonPanel, "4", display);
+        addButton(buttonPanel, "5", display);
+        addButton(buttonPanel, "6", display);
+        addButton(buttonPanel, "1", display);
+        addButton(buttonPanel, "2", display);
+        addButton(buttonPanel, "3", display);
+
+        // Add decimal button
+        JButton decimalButton = new JButton(".");
+        decimalButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (!hasDecimal) {  // Allow only one decimal point
+                    currentValue.append(".");
+                    display.setText(currentValue.toString());
+                    hasDecimal = true;
+                }
+            }
+        });
+        buttonPanel.add(decimalButton);
+        
+        // Add Backspace, 0, and +- buttons
+        addButton(buttonPanel, "0", display);
+        addToggleSignButton(buttonPanel, display);
+        addBackspaceButton(buttonPanel, display);
+        
+        // Add the number pad buttons to the panel
+        add(buttonPanel, BorderLayout.CENTER);
+
+        // Add OK and Cancel buttons
+        JPanel controlPanel = new JPanel();
+        JButton okButton = new JButton("OK");
+        okButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                resultValue = currentValue.toString();
+                // Validate the input (before accepting the value)
+                if (isValidInteger(resultValue) || isValidFloat(resultValue)) {
+                    isValid = true;
+                } else {
+                    isValid = false;
+                    resultValue = "";  // Reset result if invalid
+                    // Show an error message if the input is invalid
+                    JOptionPane.showMessageDialog(null, "Invalid input. Please enter a valid number.", "Input Error", JOptionPane.ERROR_MESSAGE);
+                    setVisible(true);
+                }
+                setVisible(false);
+            }
+        });
+        JButton cancelButton = new JButton("Cancel");
+        cancelButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                resultValue = "";
+                setVisible(false);
+            }
+        });
+        controlPanel.add(okButton);
+        controlPanel.add(cancelButton);
+        add(controlPanel, BorderLayout.SOUTH);
+
+        setSize(300, 400);
+        setLocationRelativeTo(parent);
+    }
+
+    // Return the result value after validation
+    public String getResult() {
+        return resultValue;
+    }
+
+    // Validate the input as an integer
+    private boolean isValidInteger(String value) {
+        return value.matches("-?\\d+");  // Match an optional minus sign followed by digits
+    }
+
+    // Validate the input as a float
+    private boolean isValidFloat(String value) {
+        return value.matches("-?\\d*\\.?\\d+");  // Match an optional minus sign, digits, and optional decimal
+    }
+
+    // Helper method to add a number button
+    private void addButton(JPanel panel, final String label, final JTextField display) {
+        JButton button = new JButton(label);
+        button.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                currentValue.append(label);  // Append the label (number) to the input
+                display.setText(currentValue.toString());  // Update the display
+            }
+        });
+        panel.add(button);
+    }
+
+    // Helper method for the backspace button
+    private void addBackspaceButton(JPanel panel, final JTextField display) {
+        JButton backspaceButton = new JButton("←");
+        backspaceButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (currentValue.length() > 0) {
+                    currentValue.deleteCharAt(currentValue.length() - 1);  // Remove last character
+                    display.setText(currentValue.toString());
+                }
+            }
+        });
+        panel.add(backspaceButton);
+    }
+
+    // Helper method for the toggle sign button
+    private void addToggleSignButton(JPanel panel, final JTextField display) {
+        JButton toggleSignButton = new JButton("+-");
+        toggleSignButton.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (currentValue.length() > 0) {
+                    if (isNegative) {
+                        currentValue.deleteCharAt(0);  // Remove the negative sign
+                    } else {
+                        currentValue.insert(0, "-");  // Prepend negative sign
+                    }
+                    isNegative = !isNegative;  // Toggle the sign state
+                    display.setText(currentValue.toString());
+                }
+            }
+        });
+        panel.add(toggleSignButton);
+    }
+}

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/dialog/NumberPadDialog.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/dialog/NumberPadDialog.java
@@ -46,22 +46,9 @@ public class NumberPadDialog extends JDialog {
         addButton(buttonPanel, "1", display);
         addButton(buttonPanel, "2", display);
         addButton(buttonPanel, "3", display);
-
-        // Add decimal button
-        JButton decimalButton = new JButton(".");
-        decimalButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                if (!hasDecimal) {  // Allow only one decimal point
-                    currentValue.append(".");
-                    display.setText(currentValue.toString());
-                    hasDecimal = true;
-                }
-            }
-        });
-        buttonPanel.add(decimalButton);
         
-        // Add Backspace, 0, and +- buttons
+        // Add decimal, 0, +-, and +- toggle buttons
+        addButton(buttonPanel, ".", display);
         addButton(buttonPanel, "0", display);
         addToggleSignButton(buttonPanel, display);
         addBackspaceButton(buttonPanel, display);

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
@@ -68,7 +68,7 @@ public class IOMonitorFrame extends DialogFrame {
     private final int TITLE_HEIGHT = 30;
     private final int TITLEIO_WIDTH = 100;
     private final int TITLEIO_HEIGHT = 14;
-    private final int VALUEIO_WIDTH = 35;
+    private final int VALUEIO_WIDTH = 75;
     private final int VALUEIO_HEIGHT = 14;
     private final int BUTTON_WIDTH = 100;
     private final int BUTTON_HEIGHT = 30;

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
@@ -320,6 +320,7 @@ public class IOMonitorFrame extends DialogFrame {
                         }
                     }
 
+                    // This portion handles setting bits
                     if ((mode == MODE_BITS) && (rtdeClientOfBitRegister != null)) {
                         RealTimeClient realTimeClient = new RealTimeClient("127.0.0.1");
 
@@ -333,7 +334,7 @@ public class IOMonitorFrame extends DialogFrame {
                     if ((mode == MODE_INTEGERS) && (rtdeClientOfIntegerRegister != null)) {
                         NumberPadDialog numberPadDialog = new NumberPadDialog(null);
                         numberPadDialog.setVisible(true);
-
+                        
                         String result = numberPadDialog.getResult();
                         if (!result.isEmpty()) {
                             try {
@@ -344,6 +345,24 @@ public class IOMonitorFrame extends DialogFrame {
                             } catch (NumberFormatException e) {
                                 // Handle invalid integer input, maybe show a message to the user
                                 System.out.println("Invalid integer input: " + result);
+                            }
+                        }
+                    }
+
+                    // this portion handles setting float values
+                    if ((mode == MODE_FLOATS) && (rtdeClientOfDoubleRegister != null)) {
+                        NumberPadDialog numberPadDialog = new NumberPadDialog(null);
+                        numberPadDialog.setVisible(true);
+                        String result = numberPadDialog.getResult();
+                        if (!result.isEmpty()) {
+                            try {
+                                // Check if the result is a valid float
+                                float value = Float.parseFloat(result);
+                                RealTimeClient realTimeClient = new RealTimeClient("127.0.0.1");
+                                realTimeClient.setFloatToRegister(index, value);
+                            } catch (NumberFormatException e) {
+                                // Handle invalid float input, maybe show a message to the user
+                                System.out.println("Invalid float input: " + result);
                             }
                         }
                     }

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
@@ -23,6 +23,7 @@ import com.takaaki.urcap.eipmonitor.impl.EthernetIPMonitorInstallationNodeContri
 import com.takaaki.urcap.eipmonitor.impl.component.*;
 import com.takaaki.urcap.eipmonitor.impl.converter.TypeConverter;
 import com.takaaki.urcap.eipmonitor.impl.dialog.*;
+import com.takaaki.urcap.eipmonitor.impl.dialog.NumberPadDialog;
 import com.takaaki.urcap.eipmonitor.impl.realtime.RealTimeClient;
 import com.takaaki.urcap.eipmonitor.impl.rtde.*;
 import com.ur.urcap.api.domain.URCapAPI;
@@ -327,6 +328,26 @@ public class IOMonitorFrame extends DialogFrame {
                         else
                             realTimeClient.setBitToRegister(index, true);
                     }
+
+                    // this portion handles setting integer values
+                    if ((mode == MODE_INTEGERS) && (rtdeClientOfIntegerRegister != null)) {
+                        NumberPadDialog numberPadDialog = new NumberPadDialog(null);
+                        numberPadDialog.setVisible(true);
+
+                        String result = numberPadDialog.getResult();
+                        if (!result.isEmpty()) {
+                            try {
+                                // Check if the result is a valid integer
+                                int value = Integer.parseInt(result);
+                                RealTimeClient realTimeClient = new RealTimeClient("127.0.0.1");
+                                realTimeClient.setIntegerToRegister(index, value);
+                            } catch (NumberFormatException e) {
+                                // Handle invalid integer input, maybe show a message to the user
+                                System.out.println("Invalid integer input: " + result);
+                            }
+                        }
+                    }
+
                 }
             });
         }

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
@@ -61,7 +61,7 @@ public class IOMonitorFrame extends DialogFrame {
     private final String TITLE = "Ethernet/IP: I/O Monitor";
     private final String BTN_HIDE = "Close";
 
-    private final int FRAME_WIDTH = 660;
+    private final int FRAME_WIDTH = 780;
     private final int FRAME_HEIGHT = 550;
 
     private final int TITLE_WIDTH = 480;

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/iomonitor/IOMonitorFrame.java
@@ -343,7 +343,7 @@ public class IOMonitorFrame extends DialogFrame {
                                 RealTimeClient realTimeClient = new RealTimeClient("127.0.0.1");
                                 realTimeClient.setIntegerToRegister(index, value);
                             } catch (NumberFormatException e) {
-                                // Handle invalid integer input, maybe show a message to the user
+                                // Handle invalid integer input
                                 System.out.println("Invalid integer input: " + result);
                             }
                         }
@@ -361,7 +361,7 @@ public class IOMonitorFrame extends DialogFrame {
                                 RealTimeClient realTimeClient = new RealTimeClient("127.0.0.1");
                                 realTimeClient.setFloatToRegister(index, value);
                             } catch (NumberFormatException e) {
-                                // Handle invalid float input, maybe show a message to the user
+                                // Handle invalid float input
                                 System.out.println("Invalid float input: " + result);
                             }
                         }

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/realtime/RealTimeClient.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/realtime/RealTimeClient.java
@@ -22,6 +22,11 @@ public class RealTimeClient {
         sendCommand(command);
     }
 
+    public void setIntegerToRegister(int addr, int value) {
+        String command = "write_output_integer_register(" + addr + ", " + value + ")";
+        sendCommand(command);
+    }
+
     public void sendCommand(String command) {
         try {
 

--- a/src/main/java/com/takaaki/urcap/eipmonitor/impl/realtime/RealTimeClient.java
+++ b/src/main/java/com/takaaki/urcap/eipmonitor/impl/realtime/RealTimeClient.java
@@ -27,6 +27,11 @@ public class RealTimeClient {
         sendCommand(command);
     }
 
+    public void setFloatToRegister(int addr, double value) {
+        String command = "write_output_float_register(" + addr + "," + value + ")";
+        sendCommand(command);
+    }
+
     public void sendCommand(String command) {
         try {
 


### PR DESCRIPTION
# Added Functionality
- add ability to set integers
- add ability to set doubles

# Description
- When the monitor is up, current functionality allows the user to toggle bits on / off.
- These changes allow the user to enter values for integers and doubles
- Inputs have basic validation (Ints cannot have decimals, doubles can only have one decimal point).

# Usage
- Install the URCap
- Open the monitor
- Select Ints or Doubles radio buttons
- Tap the name of the register to edit
- A basic numeric input will appear, allowing the user to enter a value
- Value can be toggled positive or negative with the "+-" button
- Invalid input is rejected
- Valid input will be set to the register
![numeric input - int](https://github.com/user-attachments/assets/3f15f0a6-ff09-4d77-a92f-abc0b294ac59)

# Limitations
- Doubles will be truncated to 3 decimals in the monitor
- Excessively long values may not appear correctly in the monitor

# Testing
- Tested in UR's virtual machine on the UR5e
- Tested on a physical UR5e

# Disclosures
- I used ChatGPT help write the numeric input portion, as java gui's are outside my area of expertise.
- While the values seem to be set correctly in the monitor and appear correctly on the robot side, I do not have the skills to dig under the hood and extensively test.